### PR TITLE
Fix lint errors by adjusting component display name and sharing import

### DIFF
--- a/app/components/shared/TitleEditorModal.tsx
+++ b/app/components/shared/TitleEditorModal.tsx
@@ -21,82 +21,83 @@ interface TitleEditorModalProps {
   title: string;
 }
 
-const TitleEditorModal = memo(
-  ({
-    visible,
-    value,
-    extensions = [".mum"],
-    selectedExtension = ".mum",
-    onChangeText,
-    onExtensionChange,
-    onSave,
-    onCancel,
-    title,
-  }: TitleEditorModalProps) => {
-    const handleSave = useCallback(() => {
-      // Perform validation before calling onSave
-      if (value.trim() !== "") {
-        onSave();
-      }
-    }, [value, onSave]);
+const TitleEditorModalComponent = ({
+  visible,
+  value,
+  extensions = [".mum"],
+  selectedExtension = ".mum",
+  onChangeText,
+  onExtensionChange,
+  onSave,
+  onCancel,
+  title,
+}: TitleEditorModalProps) => {
+  const handleSave = useCallback(() => {
+    // Perform validation before calling onSave
+    if (value.trim() !== "") {
+      onSave();
+    }
+  }, [value, onSave]);
 
-    return (
-      <Modal
-        visible={visible}
-        transparent={true}
-        animationType="fade"
-        onRequestClose={onCancel}
-      >
-        <View style={styles.modalOverlay}>
-          <View style={styles.modalContent}>
-            <Text style={styles.modalTitle}>{title}</Text>
-            <View style={styles.inputContainer}>
-              <TextInput
-                style={[
-                  styles.modalInput,
-                  extensions.length > 1
-                    ? styles.modalInputWithCombo
-                    : styles.modalInputFull,
-                ]}
-                value={value}
-                onChangeText={onChangeText}
-                placeholder="Enter pattern name"
-                autoFocus
-              />
-              {extensions.length > 1 && (
-                <View style={styles.extensionPicker}>
-                  <Picker
-                    selectedValue={selectedExtension}
-                    onValueChange={onExtensionChange}
-                    style={styles.picker}
-                  >
-                    {extensions.map((ext) => (
-                      <Picker.Item key={ext} label={ext} value={ext} />
-                    ))}
-                  </Picker>
-                </View>
-              )}
-            </View>
-            <View style={styles.modalButtons}>
-              <TouchableOpacity
-                style={[styles.modalButton, styles.cancelButton]}
-                onPress={onCancel}
-              >
-                <Text style={styles.buttonText}>Cancel</Text>
-              </TouchableOpacity>
-              <TouchableOpacity
-                style={[styles.modalButton, styles.saveButton]}
-                onPress={handleSave}
-              >
-                <Text style={styles.buttonText}>Save</Text>
-              </TouchableOpacity>
-            </View>
+  return (
+    <Modal
+      visible={visible}
+      transparent={true}
+      animationType="fade"
+      onRequestClose={onCancel}
+    >
+      <View style={styles.modalOverlay}>
+        <View style={styles.modalContent}>
+          <Text style={styles.modalTitle}>{title}</Text>
+          <View style={styles.inputContainer}>
+            <TextInput
+              style={[
+                styles.modalInput,
+                extensions.length > 1
+                  ? styles.modalInputWithCombo
+                  : styles.modalInputFull,
+              ]}
+              value={value}
+              onChangeText={onChangeText}
+              placeholder="Enter pattern name"
+              autoFocus
+            />
+            {extensions.length > 1 && (
+              <View style={styles.extensionPicker}>
+                <Picker
+                  selectedValue={selectedExtension}
+                  onValueChange={onExtensionChange}
+                  style={styles.picker}
+                >
+                  {extensions.map((ext) => (
+                    <Picker.Item key={ext} label={ext} value={ext} />
+                  ))}
+                </Picker>
+              </View>
+            )}
+          </View>
+          <View style={styles.modalButtons}>
+            <TouchableOpacity
+              style={[styles.modalButton, styles.cancelButton]}
+              onPress={onCancel}
+            >
+              <Text style={styles.buttonText}>Cancel</Text>
+            </TouchableOpacity>
+            <TouchableOpacity
+              style={[styles.modalButton, styles.saveButton]}
+              onPress={handleSave}
+            >
+              <Text style={styles.buttonText}>Save</Text>
+            </TouchableOpacity>
           </View>
         </View>
-      </Modal>
-    );
-  }
-);
+      </View>
+    </Modal>
+  );
+};
+
+const TitleEditorModal = memo(TitleEditorModalComponent);
+TitleEditorModal.displayName = "TitleEditorModal";
 
 const styles = StyleSheet.create({
   modalOverlay: {

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,6 +1,7 @@
 import { Ionicons } from "@expo/vector-icons";
 import * as DocumentPicker from "expo-document-picker";
 import * as FileSystem from "expo-file-system";
+import { shareAsync } from "expo-sharing";
 import React, { useCallback, useState } from "react";
 import {
   Platform,
@@ -278,7 +279,7 @@ export default function Index() {
         await FileSystem.writeAsStringAsync(fileUri, content);
 
         // Share the file so user can save it elsewhere
-        await FileSystem.shareAsync(fileUri, {
+        await shareAsync(fileUri, {
           mimeType: "application/json",
           dialogTitle: `Save ${fileName}.mum`,
           UTI: "public.json",


### PR DESCRIPTION
## Summary
- refactor the TitleEditorModal memoized component to have a stable display name and satisfy lint rules
- import shareAsync from expo-sharing and use it when sharing files on iOS

## Testing
- npm run lint
