### PR TITLE
feat: add persistent presets for wrap and machine tabs

### DIFF
--- a/app/components/shared/Card.tsx
+++ b/app/components/shared/Card.tsx
@@ -144,7 +144,7 @@ export default Card;
 
 */
 
-import React, { ReactNode, useState } from "react";
+import React, { ReactNode, useEffect, useState } from "react";
 import { StyleSheet, Switch, Text, View } from "react-native";
 
 interface CardProps {
@@ -163,6 +163,10 @@ const Card = ({
   onToggleChange,
 }: CardProps) => {
   const [enabled, setEnabled] = useState(initialEnabled);
+
+  useEffect(() => {
+    setEnabled(initialEnabled);
+  }, [initialEnabled]);
 
   const handleToggleChange = (value: boolean) => {
     setEnabled(value);

--- a/app/components/shared/PresetSelector.tsx
+++ b/app/components/shared/PresetSelector.tsx
@@ -1,0 +1,126 @@
+import { Picker } from "@react-native-picker/picker";
+import React from "react";
+import {
+  StyleProp,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+  ViewStyle,
+} from "react-native";
+
+interface PresetSelectorProps {
+  title: string;
+  presets: string[];
+  selectedPreset: string | null;
+  onSelectPreset: (name: string | null) => void;
+  onSavePreset: () => void;
+  onDeletePreset: () => void;
+  style?: StyleProp<ViewStyle>;
+}
+
+const PresetSelector = ({
+  title,
+  presets,
+  selectedPreset,
+  onSelectPreset,
+  onSavePreset,
+  onDeletePreset,
+  style,
+}: PresetSelectorProps) => {
+  const pickerValue = selectedPreset ?? "";
+  const hasPresets = presets.length > 0;
+  const deleteDisabled = !selectedPreset;
+
+  return (
+    <View style={[styles.container, style]}>
+      <Text style={styles.title}>{title}</Text>
+      <View style={styles.row}>
+        <View
+          style={[styles.pickerWrapper, !hasPresets && styles.disabledPicker]}
+        >
+          <Picker
+            selectedValue={pickerValue}
+            onValueChange={(value) => {
+              onSelectPreset(value === "" ? null : (value as string));
+            }}
+            enabled={hasPresets}
+            style={styles.picker}
+          >
+            <Picker.Item label={hasPresets ? "Select a preset" : "No presets saved"} value="" />
+            {presets.map((presetName) => (
+              <Picker.Item key={presetName} label={presetName} value={presetName} />
+            ))}
+          </Picker>
+        </View>
+        <TouchableOpacity style={styles.saveButton} onPress={onSavePreset}>
+          <Text style={styles.buttonText}>Save</Text>
+        </TouchableOpacity>
+        <TouchableOpacity
+          style={[styles.deleteButton, deleteDisabled && styles.disabledButton]}
+          onPress={onDeletePreset}
+          disabled={deleteDisabled}
+        >
+          <Text style={styles.buttonText}>Delete</Text>
+        </TouchableOpacity>
+      </View>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    marginBottom: 12,
+    padding: 12,
+    backgroundColor: "#f5f6fa",
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: "#dfe4ea",
+  },
+  title: {
+    fontSize: 16,
+    fontWeight: "600",
+    color: "#2f3542",
+    marginBottom: 8,
+  },
+  row: {
+    flexDirection: "row",
+    alignItems: "center",
+  },
+  pickerWrapper: {
+    flex: 1,
+    borderWidth: 1,
+    borderColor: "#dcdde1",
+    borderRadius: 6,
+    overflow: "hidden",
+    marginRight: 8,
+  },
+  disabledPicker: {
+    opacity: 0.6,
+  },
+  picker: {
+    height: 44,
+  },
+  saveButton: {
+    backgroundColor: "#2ed573",
+    paddingVertical: 10,
+    paddingHorizontal: 16,
+    borderRadius: 6,
+    marginRight: 8,
+  },
+  deleteButton: {
+    backgroundColor: "#ff6b6b",
+    paddingVertical: 10,
+    paddingHorizontal: 16,
+    borderRadius: 6,
+  },
+  disabledButton: {
+    opacity: 0.5,
+  },
+  buttonText: {
+    color: "#fff",
+    fontWeight: "600",
+  },
+});
+
+export default PresetSelector;

--- a/app/components/shared/TitleEditorModal.tsx
+++ b/app/components/shared/TitleEditorModal.tsx
@@ -19,6 +19,9 @@ interface TitleEditorModalProps {
   onSave: () => void;
   onCancel: () => void;
   title: string;
+  placeholder?: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
 }
 
 const TitleEditorModal = memo(
@@ -32,6 +35,9 @@ const TitleEditorModal = memo(
     onSave,
     onCancel,
     title,
+    placeholder = "Enter pattern name",
+    confirmLabel = "Save",
+    cancelLabel = "Cancel",
   }: TitleEditorModalProps) => {
     const handleSave = useCallback(() => {
       // Perform validation before calling onSave
@@ -60,7 +66,7 @@ const TitleEditorModal = memo(
                 ]}
                 value={value}
                 onChangeText={onChangeText}
-                placeholder="Enter pattern name"
+                placeholder={placeholder}
                 autoFocus
               />
               {extensions.length > 1 && (
@@ -82,13 +88,13 @@ const TitleEditorModal = memo(
                 style={[styles.modalButton, styles.cancelButton]}
                 onPress={onCancel}
               >
-                <Text style={styles.buttonText}>Cancel</Text>
+                <Text style={styles.buttonText}>{cancelLabel}</Text>
               </TouchableOpacity>
               <TouchableOpacity
                 style={[styles.modalButton, styles.saveButton]}
                 onPress={handleSave}
               >
-                <Text style={styles.buttonText}>Save</Text>
+                <Text style={styles.buttonText}>{confirmLabel}</Text>
               </TouchableOpacity>
             </View>
           </View>

--- a/app/tabs/ShellTab.tsx
+++ b/app/tabs/ShellTab.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { StyleSheet, View } from "react-native";
 import Card from "../components/shared/Card";
 import InputField from "../components/shared/InputField";
+import PresetSelector from "../components/shared/PresetSelector";
 
 interface ShellTabProps {
   patternName: string;
@@ -24,6 +25,11 @@ interface ShellTabProps {
   setTapeFeet: (text: string) => void;
   shellDescription: string;
   setShellDescription: (text: string) => void;
+  presetNames: string[];
+  selectedPreset: string | null;
+  onSelectPreset: (name: string | null) => void;
+  onSavePreset: () => void;
+  onDeletePreset: () => void;
 }
 
 const ShellTab = ({
@@ -47,9 +53,23 @@ const ShellTab = ({
   setTapeFeet,
   shellDescription,
   setShellDescription,
+  presetNames,
+  selectedPreset,
+  onSelectPreset,
+  onSavePreset,
+  onDeletePreset,
 }: ShellTabProps) => {
   return (
-    <Card title="Shell Size Variables">
+    <View>
+      <PresetSelector
+        title="Shell & Wrap Presets"
+        presets={presetNames}
+        selectedPreset={selectedPreset}
+        onSelectPreset={onSelectPreset}
+        onSavePreset={onSavePreset}
+        onDeletePreset={onDeletePreset}
+      />
+      <Card title="Shell Size Variables">
       <View style={styles.inputRow}>
         <InputField
           label="Pattern Name"
@@ -149,7 +169,8 @@ const ShellTab = ({
           required={true}
         />
       </View>
-    </Card>
+      </Card>
+    </View>
   );
 };
 

--- a/app/tabs/WrapTab.tsx
+++ b/app/tabs/WrapTab.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { StyleSheet, View } from "react-native";
 import Card from "../components/shared/Card";
 import InputField from "../components/shared/InputField";
+import PresetSelector from "../components/shared/PresetSelector";
 
 interface WrapTabProps {
   feedrate: string;
@@ -23,6 +24,11 @@ interface WrapTabProps {
   setStartSpeed: (text: string) => void;
   finalSpeed: string;
   setFinalSpeed: (text: string) => void;
+  presetNames: string[];
+  selectedPreset: string | null;
+  onSelectPreset: (name: string | null) => void;
+  onSavePreset: () => void;
+  onDeletePreset: () => void;
 }
 
 const WrapTab = ({
@@ -45,6 +51,11 @@ const WrapTab = ({
   setStartSpeed,
   finalSpeed,
   setFinalSpeed,
+  presetNames,
+  selectedPreset,
+  onSelectPreset,
+  onSavePreset,
+  onDeletePreset,
 }: WrapTabProps) => {
   const handleToggleChange = (enabled: boolean) => {
     setIsEnableBurnish(enabled); // Update the parent state
@@ -52,6 +63,14 @@ const WrapTab = ({
 
   return (
     <View>
+      <PresetSelector
+        title="Shell & Wrap Presets"
+        presets={presetNames}
+        selectedPreset={selectedPreset}
+        onSelectPreset={onSelectPreset}
+        onSavePreset={onSavePreset}
+        onDeletePreset={onDeletePreset}
+      />
       <Card title="Wrap Speed Variables">
         <View style={styles.inputRow}>
           <InputField

--- a/app/tabs/machineTab.tsx
+++ b/app/tabs/machineTab.tsx
@@ -3,6 +3,7 @@ import { StyleSheet, View } from "react-native";
 import AreaField from "../components/shared/AreaField";
 import Card from "../components/shared/Card";
 import InputField from "../components/shared/InputField";
+import PresetSelector from "../components/shared/PresetSelector";
 
 interface MachineTabProps {
   isEnablePump: boolean;
@@ -22,6 +23,11 @@ interface MachineTabProps {
   setEndOfMainWrap: (text: string) => void;
   endOfCompleteWrap: string;
   setEndOfCompleteWrap: (text: string) => void;
+  presetNames: string[];
+  selectedPreset: string | null;
+  onSelectPreset: (name: string | null) => void;
+  onSavePreset: () => void;
+  onDeletePreset: () => void;
 }
 
 const MachineTab = ({
@@ -41,6 +47,11 @@ const MachineTab = ({
   setEndOfMainWrap,
   endOfCompleteWrap,
   setEndOfCompleteWrap,
+  presetNames,
+  selectedPreset,
+  onSelectPreset,
+  onSavePreset,
+  onDeletePreset,
 }: MachineTabProps) => {
   const handleToggleChange = (enabled: boolean): void => {
     setIsEnablePump(enabled); // Update the parent state
@@ -48,6 +59,14 @@ const MachineTab = ({
 
   return (
     <View>
+      <PresetSelector
+        title="Machine Presets"
+        presets={presetNames}
+        selectedPreset={selectedPreset}
+        onSelectPreset={onSelectPreset}
+        onSavePreset={onSavePreset}
+        onDeletePreset={onDeletePreset}
+      />
       <Card
         title="Pump Variables"
         showToggle={true}

--- a/app/utils/presetStorage.ts
+++ b/app/utils/presetStorage.ts
@@ -1,0 +1,206 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { Platform } from "react-native";
+
+export interface ShellWrapPresetData {
+  patternName: string;
+  shellSize: string;
+  measSize: string;
+  diameter: string;
+  circ: string;
+  yaixs: string;
+  totalKick: string;
+  kickRatio: string;
+  tapeFeet: string;
+  shellDescription: string;
+  feedrate: string;
+  overwrap: string;
+  totalLayers: string;
+  perLayer: string;
+  isEnableBurnish: boolean;
+  burnishPcg: string;
+  rampStep: string;
+  startSpeed: string;
+  finalSpeed: string;
+}
+
+export interface MachinePresetData {
+  isEnablePump: boolean;
+  pumpOnCode: string;
+  pumpOffCode: string;
+  cycPerShell: string;
+  duration: string;
+  startupGCode: string;
+  endOfMainWrap: string;
+  endOfCompleteWrap: string;
+}
+
+export interface NamedPreset<T> {
+  name: string;
+  data: T;
+}
+
+const COOKIE_EXPIRATION_DAYS = 3650; // ~10 years
+
+const KEY_SHELL_PRESETS = "shellWrapPresets";
+const KEY_MACHINE_PRESETS = "machinePresets";
+const KEY_SELECTED_SHELL = "selectedShellWrapPreset";
+const KEY_SELECTED_MACHINE = "selectedMachinePreset";
+
+type StorageKey =
+  | typeof KEY_SHELL_PRESETS
+  | typeof KEY_MACHINE_PRESETS
+  | typeof KEY_SELECTED_SHELL
+  | typeof KEY_SELECTED_MACHINE;
+
+const getCookieValue = (name: string): string | null => {
+  if (typeof document === "undefined") {
+    return null;
+  }
+
+  const decodedName = decodeURIComponent(name);
+  const cookies = document.cookie ? document.cookie.split("; ") : [];
+
+  for (const cookie of cookies) {
+    const [rawName, ...rest] = cookie.split("=");
+    if (decodeURIComponent(rawName) === decodedName) {
+      return decodeURIComponent(rest.join("="));
+    }
+  }
+
+  return null;
+};
+
+const setCookieValue = (name: string, value: string): void => {
+  if (typeof document === "undefined") {
+    return;
+  }
+
+  const expires = new Date();
+  expires.setDate(expires.getDate() + COOKIE_EXPIRATION_DAYS);
+
+  document.cookie = `${encodeURIComponent(name)}=${encodeURIComponent(
+    value
+  )}; expires=${expires.toUTCString()}; path=/; SameSite=Lax`;
+};
+
+const removeCookieValue = (name: string): void => {
+  if (typeof document === "undefined") {
+    return;
+  }
+
+  document.cookie = `${encodeURIComponent(name)}=; expires=${new Date(0).toUTCString()}; path=/; SameSite=Lax`;
+};
+
+const getItem = async (key: StorageKey): Promise<string | null> => {
+  try {
+    if (Platform.OS === "web") {
+      return getCookieValue(key);
+    }
+
+    return await AsyncStorage.getItem(key);
+  } catch (error) {
+    console.warn(`Failed to retrieve ${key} from storage`, error);
+    return null;
+  }
+};
+
+const setItem = async (key: StorageKey, value: string): Promise<void> => {
+  try {
+    if (Platform.OS === "web") {
+      setCookieValue(key, value);
+      return;
+    }
+
+    await AsyncStorage.setItem(key, value);
+  } catch (error) {
+    console.warn(`Failed to persist ${key} to storage`, error);
+  }
+};
+
+const removeItem = async (key: StorageKey): Promise<void> => {
+  try {
+    if (Platform.OS === "web") {
+      removeCookieValue(key);
+      return;
+    }
+
+    await AsyncStorage.removeItem(key);
+  } catch (error) {
+    console.warn(`Failed to remove ${key} from storage`, error);
+  }
+};
+
+const parsePresetList = <T,>(raw: string | null): NamedPreset<T>[] => {
+  if (!raw) {
+    return [];
+  }
+
+  try {
+    const parsed = JSON.parse(raw) as NamedPreset<T>[];
+    if (Array.isArray(parsed)) {
+      return parsed;
+    }
+  } catch (error) {
+    console.warn("Unable to parse presets", error);
+  }
+
+  return [];
+};
+
+export const getShellWrapPresets = async (): Promise<
+  NamedPreset<ShellWrapPresetData>[]
+> => {
+  const raw = await getItem(KEY_SHELL_PRESETS);
+  return parsePresetList<ShellWrapPresetData>(raw);
+};
+
+export const saveShellWrapPresets = async (
+  presets: NamedPreset<ShellWrapPresetData>[]
+): Promise<void> => {
+  await setItem(KEY_SHELL_PRESETS, JSON.stringify(presets));
+};
+
+export const getMachinePresets = async (): Promise<
+  NamedPreset<MachinePresetData>[]
+> => {
+  const raw = await getItem(KEY_MACHINE_PRESETS);
+  return parsePresetList<MachinePresetData>(raw);
+};
+
+export const saveMachinePresets = async (
+  presets: NamedPreset<MachinePresetData>[]
+): Promise<void> => {
+  await setItem(KEY_MACHINE_PRESETS, JSON.stringify(presets));
+};
+
+export const getSelectedShellWrapPresetName = async (): Promise<string | null> => {
+  const name = await getItem(KEY_SELECTED_SHELL);
+  return name ?? null;
+};
+
+export const saveSelectedShellWrapPresetName = async (
+  name: string | null
+): Promise<void> => {
+  if (!name) {
+    await removeItem(KEY_SELECTED_SHELL);
+    return;
+  }
+
+  await setItem(KEY_SELECTED_SHELL, name);
+};
+
+export const getSelectedMachinePresetName = async (): Promise<string | null> => {
+  const name = await getItem(KEY_SELECTED_MACHINE);
+  return name ?? null;
+};
+
+export const saveSelectedMachinePresetName = async (
+  name: string | null
+): Promise<void> => {
+  if (!name) {
+    await removeItem(KEY_SELECTED_MACHINE);
+    return;
+  }
+
+  await setItem(KEY_SELECTED_MACHINE, name);
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@expo/vector-icons": "^14.1.0",
+        "@react-native-async-storage/async-storage": "^2.2.0",
         "@react-native-picker/picker": "^2.11.0",
         "@react-navigation/bottom-tabs": "^7.3.10",
         "@react-navigation/elements": "^2.3.8",
@@ -2759,6 +2760,18 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@react-native-async-storage/async-storage": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-2.2.0.tgz",
+      "integrity": "sha512-gvRvjR5JAaUZF8tv2Kcq/Gbt3JHwbKFYfmb445rhOj6NUMx3qPLixmDx5pZAyb9at1bYvJ4/eTUipU5aki45xw==",
+      "license": "MIT",
+      "dependencies": {
+        "merge-options": "^3.0.4"
+      },
+      "peerDependencies": {
+        "react-native": "^0.0.0-0 || >=0.65 <1.0"
       }
     },
     "node_modules/@react-native-picker/picker": {
@@ -7746,6 +7759,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -8731,6 +8753,18 @@
       "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
       "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
       "license": "MIT"
+    },
+    "node_modules/merge-options": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-3.0.4.tgz",
+      "integrity": "sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-plain-obj": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@expo/vector-icons": "^14.1.0",
+    "@react-native-async-storage/async-storage": "^2.2.0",
     "@react-native-picker/picker": "^2.11.0",
     "@react-navigation/bottom-tabs": "^7.3.10",
     "@react-navigation/elements": "^2.3.8",


### PR DESCRIPTION
## Summary
- add a shared preset selector and render it on the shell, wrap, and machine tabs
- persist shell/wrap and machine presets with cookie storage on web and AsyncStorage on native
- provide preset save/delete flows with name prompts and sync toggle cards with state updates

## Testing
- npm run lint

------
